### PR TITLE
Replace obsolete compile with implementation when linking manually

### DIFF
--- a/docs/install-vasern.md
+++ b/docs/install-vasern.md
@@ -37,7 +37,7 @@ $ npm install --save vasern
 
         ```diff
         dependencies {
-        +   compile project(':vasern')
+        +   implementation project(':vasern')
 
             implementation fileTree(dir: "libs", include: ["*.jar"])
             implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"

--- a/website/versioned_docs/version-0.2.7-alpha/install-vasern.md
+++ b/website/versioned_docs/version-0.2.7-alpha/install-vasern.md
@@ -39,7 +39,7 @@ $ npm install --save vasern
 
         ```diff
         dependencies {
-        +   compile project(':vasern')
+        +   implementation project(':vasern')
 
             implementation fileTree(dir: "libs", include: ["*.jar"])
             implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"

--- a/website/versioned_docs/version-0.3.0-beta/install-vasern.md
+++ b/website/versioned_docs/version-0.3.0-beta/install-vasern.md
@@ -38,7 +38,7 @@ $ npm install --save vasern
 
         ```diff
         dependencies {
-        +   compile project(':vasern')
+        +   implementation project(':vasern')
 
             implementation fileTree(dir: "libs", include: ["*.jar"])
             implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"


### PR DESCRIPTION
Just a small change to also replace the obsolete compile flag with implementation for everyone following installation instructions on vasern.com and linking manually